### PR TITLE
Ability to build VirtualBox images with i386 and amd64 architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,26 @@ beaglebone: prep
 	@echo "Build complete."
 
 # build a virtualbox image
-virtualbox: prep
+virtualbox: virtualbox-i386
+
+virtualbox-i386: prep
 	$(eval ARCHITECTURE = i386)
 	$(eval MACHINE = virtualbox)
 	$(eval DESTINATION = hdd)
 	$(MAKE_IMAGE)
-# Convert image to vdi hard drive
+	# Convert image to vdi hard drive
+	VBoxManage convertdd $(NAME).img $(NAME).vdi
+	$(TAR) $(ARCHIVE) $(NAME).vdi
+	@echo ""
+	$(SIGN)
+	@echo "Build complete."
+
+virtualbox-amd64: prep
+	$(eval ARCHITECTURE = amd64)
+	$(eval MACHINE = virtualbox)
+	$(eval DESTINATION = hdd)
+	$(MAKE_IMAGE)
+	# Convert image to vdi hard drive
 	VBoxManage convertdd $(NAME).img $(NAME).vdi
 	$(TAR) $(ARCHIVE) $(NAME).vdi
 	@echo ""


### PR DESCRIPTION
The changes in this branch introduce the ability to build VirtualBox images for both i386 and amd64 architectures. The target `virtualbox` still builds the i386 architecture image.  To build amd64 image the target is `virtualbox-amd64`.

Both images have been tested by building and booting them in VirtualBox.