### PR TITLE
Add ability to set build and image mirrors separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Where to fetch packages
 MIRROR = http://http.debian.net/debian
-
+BUILD_MIRROR = http://http.debian.net/debian
 # armel amd64 i386
 ARCHITECTURE = armel
 # dreamplug guruplug virtualbox raspberry(pi)
@@ -27,6 +27,7 @@ SIGN = -gpg --output $(SIGNATURE) --detach-sig $(ARCHIVE)
 # hang. (See Debian bug #769983 for details.)
 MAKE_IMAGE = ARCHITECTURE=$(ARCHITECTURE) DESTINATION=$(DESTINATION) \
     MACHINE=$(MACHINE) SOURCE=$(SOURCE) MIRROR=$(MIRROR) SUITE=$(SUITE) OWNER=$(OWNER) \
+    BUILD_MIRROR=$(BUILD_MIRROR) \
     taskset 0x01 bin/mk_freedombox_image $(NAME)
 
 # build DreamPlug USB or SD card image

--- a/bin/freedombox-customize
+++ b/bin/freedombox-customize
@@ -46,6 +46,17 @@ disable_eatmydata_override() {
     sync # Flush file buffers before continuing
 }
 
+set_apt_sources() {
+    NEW_MIRROR="$1"
+    cat <<EOF > etc/apt/sources.list
+deb $NEW_MIRROR $SUITE main contrib non-free
+deb-src $NEW_MIRROR $SUITE main contrib non-free
+
+#deb http://security.debian.org/ $SUITE/updates main
+#deb-src http://security.debian.org/ $SUITE/updates main
+EOF
+}
+
 # Set to true/false to control if eatmydata is used during build
 use_eatmydata=true
 
@@ -79,13 +90,7 @@ case "$MACHINE" in
         ;;
 esac
 
-cat <<EOF > etc/apt/sources.list
-deb $MIRROR $SUITE main contrib non-free
-deb-src $MIRROR $SUITE main contrib non-free
-
-#deb http://security.debian.org/ $SUITE/updates main
-#deb-src http://security.debian.org/ $SUITE/updates main
-EOF
+set_apt_sources $BUILD_MIRROR
 chroot $rootdir apt-get update
 
 cat > $rootdir/usr/sbin/policy-rc.d <<EOF
@@ -108,6 +113,9 @@ chroot $rootdir /usr/lib/freedombox/setup 2>&1 | \
 if $use_eatmydata ; then
     disable_eatmydata_override
 fi
+
+set_apt_sources $MIRROR
+chroot $rootdir apt-get update
 
 cd /
 echo "info: killing leftover processes in chroot"

--- a/bin/mk_freedombox_image
+++ b/bin/mk_freedombox_image
@@ -117,6 +117,7 @@ echo "starting vmdebootstrap"
 sudo -H \
     SUITE="$SUITE" \
     MIRROR="$MIRROR" \
+    BUILD_MIRROR="$BUILD_MIRROR"\
     DESTINATION="$DESTINATION" \
     MACHINE="$MACHINE" \
     ARCHITECTURE="$ARCHITECTURE" \
@@ -127,7 +128,7 @@ sudo -H \
     --image $IMAGE.img \
     --hostname freedombox \
     --verbose \
-    --mirror $MIRROR \
+    --mirror $BUILD_MIRROR \
     --customize "$basedir/bin/freedombox-customize" \
     --lock-root-password \
     --arch $ARCHITECTURE \


### PR DESCRIPTION
Currently if a local Debian mirror such as apt-cacher-ng is set
during build, the resulting images will also contain the same
mirror which is not desirable.

This patch separates the mirror used to build the image from the
mirror used inside the final image.  By default build mirror and
image mirror are the same.  However, build mirror can be specified
by passing an environment variable BUILD_MIRROR to the make command.

make -e BUILD_MIRROR=<build_mirror>

user concern to set mirrors.