### PR TITLE
Remove unneeded DHCP config option to vmdebootstrap

### DIFF
--- a/bin/mk_freedombox_image
+++ b/bin/mk_freedombox_image
@@ -160,6 +160,5 @@ sudo -H \
     --lock-root-password \
     --arch $ARCHITECTURE \
     --distribution $SUITE \
-    --enable-dhcp \
     $extra_opts \
     $pkgopts


### PR DESCRIPTION
With the option set, vmdebootstrap will generate an /etc/network/interfaces with DHCP configuration for eth0.  Earlier this file was getting overwritten so no harm done.  But now, we have a patch proposed to freedombox-setup that uses network-manager and will suffer if eth0 is mentioned in /etc/network/interfaces.