### PR TITLE
Support A20 OLinuXino Lime2 and MICRO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,26 @@ cubietruck: prep
 	$(SIGN)
 	@echo "Build complete."
 
+# build A20 OLinuXino Lime2 SD card image
+a20-olinuxino-lime2: prep
+	$(eval ARCHITECTURE = armhf)
+	$(eval MACHINE = a20-olinuxino-lime2)
+	$(MAKE_IMAGE)
+	$(TAR) $(ARCHIVE) $(IMAGE)
+	@echo ""
+	$(SIGN)
+	@echo "Build complete."
+
+# build A20 OLinuXino MIRCO SD card image
+a20-olinuxino-micro: prep
+	$(eval ARCHITECTURE = armhf)
+	$(eval MACHINE = a20-olinuxino-micro)
+	$(MAKE_IMAGE)
+	$(TAR) $(ARCHIVE) $(IMAGE)
+	@echo ""
+	$(SIGN)
+	@echo "Build complete."
+
 # build an i386 image
 i386: prep
 	$(eval ARCHITECTURE = i386)

--- a/bin/freedombox-customize
+++ b/bin/freedombox-customize
@@ -147,6 +147,14 @@ case "$MACHINE" in
         dd if=$rootdir/usr/lib/u-boot/Cubietruck/u-boot-sunxi-with-spl.bin of="$image" \
            seek=8 conv=notrunc bs=1k
         ;;
+    a20-olinuxino-lime2)
+        dd if=$rootdir/usr/lib/u-boot/A20-OLinuXino-Lime2/u-boot-sunxi-with-spl.bin \
+           of="$image" seek=8 conv=notrunc bs=1k
+        ;;
+    a20-olinuxino-micro)
+        dd if=$rootdir/usr/lib/u-boot/A20-OLinuXino_MICRO/u-boot-sunxi-with-spl.bin \
+           of="$image" seek=8 conv=notrunc bs=1k
+        ;;
 esac
 
 if $use_eatmydata ; then

--- a/bin/hardware-setup
+++ b/bin/hardware-setup
@@ -189,19 +189,21 @@ beaglebone_repack_kernel() {
 	-d $initRd uInitrd )
 }
 
-cubietruck_setup_boot() {
+a20_setup_boot() {
+    dtb="$1"
+
     # Setup boot.cmd
     if grep -q btrfs /etc/fstab ; then
 	fstype=btrfs
     else
 	fstype=ext4
     fi
-    kernelVersion=$(ls /usr/lib/*/sun7i-a20-cubietruck.dtb | head -1 | cut -d/ -f4)
+    kernelVersion=$(ls /usr/lib/*/$dtb | head -1 | cut -d/ -f4)
     version=$(echo $kernelVersion | sed 's/linux-image-\(.*\)/\1/')
     initRd=initrd.img-$version
     vmlinuz=vmlinuz-$version
 
-    # boot.cmd for CubieTruck
+    # Create boot.cmd
     cat >> /boot/boot.cmd <<EOF
 setenv mmcdev 0
 setenv mmcpart 1
@@ -214,6 +216,7 @@ setenv console ttyS0,115200n8
 
 setenv kernel_file $vmlinuz
 setenv initrd_file $initRd
+setenv fdtfile $dtb
 
 setenv loadaddr 0x46000000
 setenv initrd_addr 0x48000000
@@ -232,10 +235,10 @@ setenv mmcargs setenv bootargs console=\${console} root=\${mmcroot} rootfstype=\
 run loadfiles; run mmcargs; bootz \${loadaddr} \${initrd_addr}:\${initrd_size} \${fdtaddr}
 EOF
 
-    # boot.scr for CubieTruck
+    # boot.scr for Allwinner A20 based device
     mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
 
-    # DTBs for CubieTruck
+    # Copy all DTBs
     mkdir -p /boot/dtbs
     cp /usr/lib/$kernelVersion/* /boot/dtbs
 
@@ -263,7 +266,15 @@ case "$MACHINE" in
 	enable_serial_console ttyO0
 	;;
     cubietruck)
-	cubietruck_setup_boot
+	a20_setup_boot sun7i-a20-cubietruck.dtb
 	enable_serial_console ttyS0
 	;;
+    a20-olinuxino-lime2)
+	a20_setup_boot sun7i-a20-olinuxino-lime2.dtb
+	enable_serial_console ttyS0
+        ;;
+    a20-olinuxino-micro)
+	a20_setup_boot sun7i-a20-olinuxino-micro.dtb
+	enable_serial_console ttyS0
+        ;;
 esac

--- a/bin/mk_freedombox_image
+++ b/bin/mk_freedombox_image
@@ -44,8 +44,11 @@ dreamplug_pkgs="linux-image-kirkwood u-boot-tools u-boot"
 # Packages needed on the beaglebone
 beaglebone_pkgs="linux-image-armmp u-boot-tools u-boot"
 
-# Packages needed on the cubietruck
-cubietruck_pkgs="linux-image-armmp-lpae u-boot-tools u-boot"
+# Packages needed on the Allwinner A20 devices:
+#  - Cubietruck
+#  - A20 OLinuXino LIME2
+#  - A20 OLinuXino MICRO
+a20_pkgs="linux-image-armmp-lpae u-boot-tools u-boot"
 
 # Packages needed for self-hosted development
 dev_pkgs="build-essential devscripts make man-db emacs org-mode git mercurial"
@@ -103,8 +106,8 @@ case "$MACHINE" in
  --roottype btrfs \
 "
 	;;
-    cubietruck)
-       extra_pkgs="$cubietruck_pkgs"
+    cubietruck | a20-olinuxino-lime2 | a20-olinuxino-micro)
+       extra_pkgs="$a20_pkgs"
        extra_opts="\
  --variant minbase \
  --bootoffset=1mib \


### PR DESCRIPTION
The pull request adds support for:
- A20 OLinuXino Lime2
- A20 OLinuXino MICRO

I have tested with A20 OLinuXino MICRO to boot well and access Plinth functions. I have also built Cubietruck image to check for regressions and test it.  I could not test Lime2 due to poor power supply.

The change to explicitly set the value of ${fdtfile} in u-boot script is something I am sure is the best one.  When we choose the appropriate u-boot for the device, it comes hardcoded with the appropriate DTB value for this variable.  If we can remove the detection of kernel version using a DTB file name (say by assuming there will be only one kernel installed at the time of script execution and that it will contain the necessary DTB), then we can generalize a20_setup() to work for all Allwinner A20 devices.  However, I made this change as anyway we have to pass in the DTB value and we might as well set is explicitly.