### PR TITLE
Create qemu images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,31 @@ test-virtualbox: virtualbox
 	VBoxManage modifyvm $(VM_NAME) --hda none
 	VBoxManage unregistervm $(VM_NAME) --delete
 
+# build a qemu image
+qemu: qemu-i386
+
+qemu-i386: prep
+	$(eval ARCHITECTURE = i386)
+	$(eval MACHINE = qemu)
+	$(MAKE_IMAGE)
+	# Convert image to qemu format
+	qemu-img convert -O qcow2 $(NAME).img $(NAME).qcow2
+	$(TAR) $(ARCHIVE) $(NAME).qcow2
+	@echo ""
+	$(SIGN)
+	@echo "Build complete."
+
+qemu-x86_64: prep
+	$(eval ARCHITECTURE = x86_64)
+	$(eval MACHINE = qemu)
+	$(MAKE_IMAGE)
+	# Convert image to qemu format
+	qemu-img convert -O qcow2 $(NAME).img $(NAME).qcow2
+	$(TAR) $(ARCHIVE) $(NAME).qcow2
+	@echo ""
+	$(SIGN)
+	@echo "Build complete."
+
 vendor/vmdebootstrap/vmdebootstrap: vendor-patches/vmdebootstrap/*.patch
 	bin/fetch-new-vmdebootstrap
 

--- a/README
+++ b/README
@@ -31,6 +31,8 @@ Freedom-maker supports building for the following targets:
 - *amd64*: Disk image for any machine with amd64 architecture.
 - *virtualbox-i386*: 32-bit image for the VirtualBox virtualization tool
 - *virtualbox-amd64*: 64-bit image for the VirtualBox virtualization tool
+- *qemu-i386*: 32-bit image for the Qemu virtualization tool
+- *qemu-x86_64*: 64-bit image for the Qemu virtualization tool
 - *test*: build virtualbox i386 image and run diagnostics tests on it
 
 ## Install dependencies
@@ -46,6 +48,11 @@ $ sudo apt-get -y install git sudo vmdebootstrap dosfstools btrfs-tools
 For VirtualBox:
 ```
 $ sudo apt-get -y install extlinux virtualbox
+```
+
+For Qemu:
+```
+$ sudo apt-get -y install qemu
 ```
 
 For RaspberryPi:
@@ -73,12 +80,13 @@ $ sudo apt-get install extlinux virtualbox sshpass
 2. Build all images:
     ```
     $ sudo make -C freedom-maker dreamplug raspberry beaglebone \
-      cubietruck i386 amd64 virtualbox-i386 virtualbox-amd64
+      cubietruck i386 amd64 virtualbox-i386 virtualbox-amd64 \
+      qemu-i386 qemu-x86_64
     ```
 
     or to build just a single image:
     ```
-    $ sudo make -C freedom-maker beaglebone 
+    $ sudo make -C freedom-maker beaglebone
     ```
 
 The images will show up in *freedom-maker/build/*. Copy the image to


### PR DESCRIPTION
Virtualbox is not available on Trisquel, so qemu is an alternative. This generates qcow2 images which can then be run using qemu-system-i386 or qemu-system-x86_64. It requires the qemu package to be installed.