### PR TITLE
Use ext2 for boot partition on A20 devices

### DIFF
--- a/bin/mk_freedombox_image
+++ b/bin/mk_freedombox_image
@@ -112,7 +112,7 @@ case "$MACHINE" in
  --variant minbase \
  --bootoffset=1mib \
  --bootsize 128M \
- --boottype vfat \
+ --boottype ext2 \
  --no-kernel \
  --no-extlinux \
  --foreign /usr/bin/qemu-arm-static \


### PR DESCRIPTION
The following patch is untested even though it comes with high confidence.  When we make the release builds for 0.7 soon, we will be testing this on all supported A20 devices.

The initrd creation tools can't handle the /boot partition being vfat
type.  Permissions and ownership can't be preserved and typical kernel
upgrade fails.

On A20 devices, the BROM (32kb of non-writable GPL2 code) boots disks in
a particular order.  A Secondar Program Loader (SPL) is booted at 8K
offset on the disk which then boots u-boot at another offset.  BROM does
not need to understand the filesystem to boot a disk.  Neither does the
SPL.  After this U-boot loads kernel, initrd and device tree before
starting the kernel.  For us, SPL and U-boot both come from mainline
U-boot which supports booting ext2.