### PR TITLE
Handle spaces in paths properly

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -141,7 +141,7 @@ fi
 
 atheros_wifi
 
-script_dir=$(cd $(dirname "$0") && pwd)
+script_dir=$(cd "$(dirname "$0")" && pwd)
 cp "$script_dir"/hardware-setup $rootdir/tmp
 chroot $rootdir /tmp/hardware-setup 2>&1 | \
     tee $rootdir/var/log/hardware-setup.log


### PR DESCRIPTION
Currently, running hardware script when there are spaces in paths fails. The patch fixes it.