### PR TITLE
Cubietruck and other fixes

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -86,8 +86,8 @@ atheros_wifi() {
 use_eatmydata=true
 
 rootdir="$1"
-fmdir="$(pwd)"
-image="$fmdir"/"$2"
+image="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
+
 cd "$rootdir"
 
 echo info: building $MACHINE

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -201,60 +201,12 @@ beaglebone_repack_kernel() {
 	-d $initRd uInitrd )
 }
 
-a20_setup_boot() {
-    dtb="$1"
-
-    # Setup boot.cmd
-    if grep -q btrfs /etc/fstab ; then
-	fstype=btrfs
-    else
-	fstype=ext4
+setup_flash_kernel() {
+    if [ ! -d /etc/flash-kernel ] ; then
+       mkdir /etc/flash-kernel
     fi
-    kernelVersion=$(ls /usr/lib/*/$dtb | head -1 | cut -d/ -f4)
-    version=$(echo $kernelVersion | sed 's/linux-image-\(.*\)/\1/')
-    initRd=initrd.img-$version
-    vmlinuz=vmlinuz-$version
-
-    # Create boot.cmd
-    cat >> /boot/boot.cmd <<EOF
-setenv mmcdev 0
-setenv mmcpart 1
-
-setenv mmcroot /dev/mmcblk0p2 ro
-setenv mmcrootfstype $fstype rootwait fixrtc
-
-setenv console ttyS0,115200n8
-
-setenv kernel_file $vmlinuz
-setenv initrd_file $initRd
-setenv fdtfile $dtb
-
-setenv loadaddr 0x46000000
-setenv initrd_addr 0x48000000
-setenv fdtaddr 0x47000000
-
-setenv initrd_high 0xffffffff
-setenv fdt_high 0xffffffff
-
-setenv loadkernel load mmc \${mmcdev}:\${mmcpart} \${loadaddr} \${kernel_file}
-setenv loadinitrd load mmc \${mmcdev}:\${mmcpart} \${initrd_addr} \${initrd_file}\\; setenv initrd_size \\\${filesize}
-setenv loadfdt load mmc \${mmcdev}:\${mmcpart} \${fdtaddr} /dtbs/\${fdtfile}
-
-setenv loadfiles run loadkernel\\; run loadinitrd\\; run loadfdt
-setenv mmcargs setenv bootargs console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype}
-
-run loadfiles; run mmcargs; bootz \${loadaddr} \${initrd_addr}:\${initrd_size} \${fdtaddr}
-EOF
-
-    # boot.scr for Allwinner A20 based device
-    mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
-
-    # Copy all DTBs
-    mkdir -p /boot/dtbs
-    cp /usr/lib/$kernelVersion/* /boot/dtbs
-
-    # extra boot modules
-    echo "rtc_sunxi" >> /etc/initramfs-tools/modules
+    echo -n "$1" > /etc/flash-kernel/machine
+    apt-get install -y flash-kernel
 }
 
 case "$MACHINE" in
@@ -277,23 +229,23 @@ case "$MACHINE" in
 	enable_serial_console ttyO0
 	;;
     cubietruck)
-	a20_setup_boot sun7i-a20-cubietruck.dtb
+        setup_flash_kernel 'Cubietech Cubietruck'
 	enable_serial_console ttyS0
 	;;
     a20-olinuxino-lime)
-	a20_setup_boot sun7i-a20-olinuxino-lime.dtb
+        setup_flash_kernel 'Olimex A20-OLinuXino-LIME'
 	enable_serial_console ttyS0
         ;;
     a20-olinuxino-lime2)
-	a20_setup_boot sun7i-a20-olinuxino-lime2.dtb
+        setup_flash_kernel 'Olimex A20-OLinuXino-LIME2'
 	enable_serial_console ttyS0
         ;;
     a20-olinuxino-micro)
-	a20_setup_boot sun7i-a20-olinuxino-micro.dtb
+        setup_flash_kernel 'Olimex A20-Olinuxino Micro'
 	enable_serial_console ttyS0
         ;;
     cubieboard2)
-	a20_setup_boot sun7i-a20-cubieboard2.dtb
+	setup_flash_kernel 'Cubietech Cubieboard2'
 	enable_serial_console ttyS0
         ;;
 esac

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -124,7 +124,6 @@ beaglebone_setup_boot() {
     cat >> /boot/uEnv.txt <<EOF
 mmcroot=/dev/mmcblk0p2 ro
 mmcrootfstype=$fstype rootwait fixrtc
-mmcrootflags=subvol=@
 
 console=ttyO0,115200n8
 
@@ -143,7 +142,7 @@ loadinitrd=load mmc \${mmcdev}:\${mmcpart} \${initrd_addr} \${initrd_file}; sete
 loadfdt=load mmc \${mmcdev}:\${mmcpart} \${fdtaddr} /dtbs/\${fdtfile}
 
 loadfiles=run loadkernel; run loadinitrd; run loadfdt
-mmcargs=setenv bootargs console=tty0 console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype} rootflags=\${mmcrootflags}
+mmcargs=setenv bootargs console=tty0 console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype}
 
 uenvcmd=run loadfiles; run mmcargs; bootz \${loadaddr} \${initrd_addr}:\${initrd_size} \${fdtaddr}
 EOF
@@ -223,7 +222,6 @@ setenv mmcpart 1
 
 setenv mmcroot /dev/mmcblk0p2 ro
 setenv mmcrootfstype $fstype rootwait fixrtc
-setenv mmcrootflags subvol=@
 
 setenv console ttyS0,115200n8
 
@@ -243,7 +241,7 @@ setenv loadinitrd load mmc \${mmcdev}:\${mmcpart} \${initrd_addr} \${initrd_file
 setenv loadfdt load mmc \${mmcdev}:\${mmcpart} \${fdtaddr} /dtbs/\${fdtfile}
 
 setenv loadfiles run loadkernel\\; run loadinitrd\\; run loadfdt
-setenv mmcargs setenv bootargs console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype} rootflags=\${mmcrootflags}
+setenv mmcargs setenv bootargs console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype}
 
 run loadfiles; run mmcargs; bootz \${loadaddr} \${initrd_addr}:\${initrd_size} \${fdtaddr}
 EOF


### PR DESCRIPTION
The patchset fixes the following issues:

- When output directory is absolute path, writing u-boot firmware to image fails.

- Use flash-kernel for A20 based devices since it seems to work fine.

- Remove subvol=@ root file system parameter so that we work properly with upstream vmdebootstrap.

I have tested all the above by building a Cubietruck image with this branch.