### PR TITLE
Mount basic file systems during customize

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -82,12 +82,30 @@ atheros_wifi() {
     exit 1
 }
 
+mount_file_systems() {
+    mount /dev     -t devfs  -o bind "$rootdir/dev"
+    mount /dev/pts -t devpts -o bind "$rootdir/dev/pts"
+    mount /proc    -t proc   -o bind "$rootdir/proc"
+    mount /sys     -t sys    -o bind "$rootdir/sys"
+}
+
+unmount_file_systems() {
+    umount "$rootdir/dev/pts"
+    umount "$rootdir/dev"
+    umount "$rootdir/proc"
+    umount "$rootdir/sys"
+}
+
 # Set to true/false to control if eatmydata is used during build
 use_eatmydata=true
 
 rootdir="$1"
 fmdir="$(pwd)"
 image="$fmdir"/"$2"
+
+mount_file_systems
+trap unmount_file_systems EXIT
+
 cd "$rootdir"
 
 echo info: building $MACHINE


### PR DESCRIPTION
This allows plinth --setup to run properly.

This patch was actually tested on top of my cubietruck-fixes.  But it is really independent.  So, I am submitting it separately.  To test, I have built and amd64 image with corresponding patch to run plinth --setup in freedombox-setup.  The setup log showed that mounts happed properly and so did unmounts. Making use of the mounts, Plinth setup also ran as expected.

