### PR TITLE
Use pxz for compression with full CPU usage

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ image as follows:
 
 For all images:
 ```
-$ sudo apt-get -y install git sudo vmdebootstrap dosfstools btrfs-tools
+$ sudo apt-get -y install git sudo vmdebootstrap dosfstools btrfs-tools pxz
 ```
 
 For VirtualBox:

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -22,6 +22,7 @@ Worker class to run various command build the image.
 
 import logging
 import os
+import shutil
 import subprocess
 
 BASE_PACKAGES = [
@@ -252,8 +253,11 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
                         archive_file)
             return
 
-        options = ['--no-warn', '--best', '--force']
-        self._run(['xz'] + options + [image_file])
+        command = ['xz', '--no-warn', '--best', '--force']
+        if shutil.which('pxz'):
+            command = ['pxz', '-9', '--force']
+
+        self._run(command + [image_file])
 
     def sign(self, archive):
         """Signed the final output image."""


### PR DESCRIPTION
pxz spawns multiple threads to compress.  By default the number of
threads are the same as number of CPU cores.  The compression factor
usually suffers but only by a few megabytes.

With this change x86 build takes just 10 minutes on SSD + 8 cores.