### PR TITLE
Beagle Bone Black cleanup

### DIFF
--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -206,6 +206,16 @@ setup_flash_kernel() {
        mkdir /etc/flash-kernel
     fi
     echo -n "$1" > /etc/flash-kernel/machine
+
+    command_line=""
+    if [ -n "$2" ] ; then
+        command_line="console=$2"
+    fi
+
+    if [ -n "$command_line" ] ; then
+        echo flash-kernel flash-kernel/linux_cmdline string "$command_line" | debconf-set-selections
+    fi
+
     apt-get install -y flash-kernel
 }
 
@@ -230,22 +240,17 @@ case "$MACHINE" in
 	;;
     cubietruck)
         setup_flash_kernel 'Cubietech Cubietruck'
-	enable_serial_console ttyS0
 	;;
     a20-olinuxino-lime)
         setup_flash_kernel 'Olimex A20-OLinuXino-LIME'
-	enable_serial_console ttyS0
         ;;
     a20-olinuxino-lime2)
         setup_flash_kernel 'Olimex A20-OLinuXino-LIME2'
-	enable_serial_console ttyS0
         ;;
     a20-olinuxino-micro)
         setup_flash_kernel 'Olimex A20-Olinuxino Micro'
-	enable_serial_console ttyS0
         ;;
     cubieboard2)
 	setup_flash_kernel 'Cubietech Cubieboard2'
-	enable_serial_console ttyS0
         ;;
 esac

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -107,99 +107,6 @@ raspberry2_setup_boot() {
     raspberry_setup_boot
 }
 
-beaglebone_setup_boot() {
-    # Setup uEnv.txt
-    if grep -q btrfs /etc/fstab ; then
-	fstype=btrfs
-    else
-	fstype=ext4
-    fi
-    kernelVersion=$(ls /usr/lib/*/am335x-boneblack.dtb | head -1 | cut -d/ -f4)
-    version=$(echo $kernelVersion | sed 's/linux-image-\(.*\)/\1/')
-    initRd=initrd.img-$version
-    vmlinuz=vmlinuz-$version
-
-    # uEnv.txt for Beaglebone
-    # based on https://github.com/beagleboard/image-builder/blob/master/target/boot/beagleboard.org.txt
-    cat >> /boot/uEnv.txt <<EOF
-mmcroot=/dev/mmcblk0p2 ro
-mmcrootfstype=$fstype rootwait fixrtc
-
-console=ttyO0,115200n8
-
-kernel_file=$vmlinuz
-initrd_file=$initRd
-
-loadaddr=0x80200000
-initrd_addr=0x81000000
-fdtaddr=0x80F80000
-
-initrd_high=0xffffffff
-fdt_high=0xffffffff
-
-loadkernel=load mmc \${mmcdev}:\${mmcpart} \${loadaddr} \${kernel_file}
-loadinitrd=load mmc \${mmcdev}:\${mmcpart} \${initrd_addr} \${initrd_file}; setenv initrd_size \${filesize}
-loadfdt=load mmc \${mmcdev}:\${mmcpart} \${fdtaddr} /dtbs/\${fdtfile}
-
-loadfiles=run loadkernel; run loadinitrd; run loadfdt
-mmcargs=setenv bootargs console=tty0 console=\${console} root=\${mmcroot} rootfstype=\${mmcrootfstype}
-
-uenvcmd=run loadfiles; run mmcargs; bootz \${loadaddr} \${initrd_addr}:\${initrd_size} \${fdtaddr}
-EOF
-
-    mkdir -p /boot/dtbs
-    cp /usr/lib/linux-image-*-armmp/* /boot/dtbs
-}
-
-beaglebone_flash() {
-    # allow flash-kernel to work without valid /proc contents
-    # ** this doesn't *really* work, since there are too many checks
-    #    that fail in an emulated environment!  We'll have to do it by
-    #    hand below anyway...
-    export FK_MACHINE="TI AM335x BeagleBone"
-    apt-get install -y flash-kernel
-}
-
-beaglebone_repack_kernel() {
-# process installed kernel to create uImage, uInitrd, dtb
-# using flash-kernel would be a good approach, except it fails in the
-# cross build environment due to too many environment checks...
-#FK_MACHINE="TI AM335x BeagleBone" flash-kernel
-#  so, let's do it manually...
-
-# flash-kernel's hook-functions provided to mkinitramfs have the
-# unfortunate side-effect of creating /conf/param.conf in the initrd
-# when run from our emulated chroot environment, which means our root=
-# on the kernel command line is completely ignored!  repack the initrd
-# to remove this evil...
-
-    echo "info: repacking beaglebone kernel and initrd"
-
-    kernelVersion=$(ls /usr/lib/*/am335x-boneblack.dtb | head -1 | cut -d/ -f4)
-    version=$(echo $kernelVersion | sed 's/linux-image-\(.*\)/\1/')
-    initRd=initrd.img-$version
-    vmlinuz=vmlinuz-$version
-
-    mkdir /tmp/initrd-repack
-
-    (cd /tmp/initrd-repack ; \
-	zcat /boot/$initRd | cpio -i ; \
-	rm -f conf/param.conf ; \
-	find . | cpio --quiet -o -H newc | \
-	gzip -9 > /boot/$initRd )
-
-    rm -rf /tmp/initrd-repack
-
-    (cd /boot ; \
-	cp /usr/lib/$kernelVersion/am335x-boneblack.dtb dtb ; \
-	cat $vmlinuz dtb >> temp-kernel ; \
-	mkimage -A arm -O linux -T kernel -n "Debian kernel ${version}" \
-	-C none -a 0x80200000 -e 0x80200000 -d temp-kernel uImage ; \
-	rm -f temp-kernel ; \
-	mkimage -A arm -O linux -T ramdisk -C gzip -a 0x81000000 -e 0x81000000 \
-	-n "Debian ramdisk ${version}" \
-	-d $initRd uInitrd )
-}
 
 setup_flash_kernel() {
     if [ ! -d /etc/flash-kernel ] ; then
@@ -233,10 +140,7 @@ case "$MACHINE" in
 	raspberry2_setup_boot
 	;;
     beaglebone)
-	beaglebone_setup_boot
-	beaglebone_flash
-	beaglebone_repack_kernel
-	enable_serial_console ttyO0
+        setup_flash_kernel 'TI AM335x BeagleBone Black' 'ttyO0'
 	;;
     cubietruck)
         setup_flash_kernel 'Cubietech Cubietruck'


### PR DESCRIPTION
The first patch removes adding console settings to /etc/inittab as this is unnecessary with systemd.

Second patch uses flash-kernel for beaglebone. Adding `console=ttyO0` is necessary in this case as the boot loader does not automatically this to the kernel arguments.

I have tested the following:
* I have tested a Cubietruck image built with this patch.
* I have tested a Beaglebone image built with this patch.
* The root file system was being found using UUID= argument picked up from /etc/fstab and added as /conf/conf.d/default_root into initramfs.  This solved the problem with BBB unpredictable root devices.
* For both images, the console was available on serial debug terminal.
* Patch was slightly different when i built images.  I was doing additional ttyS0 argument to setup_flash_kernel() with the patch.  After booting, i have removed this from flash-kernel's kernel parameters manually and tested that it works okay.