### PR TITLE
Ignore errors during unmount

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -90,10 +90,13 @@ mount_file_systems() {
 }
 
 unmount_file_systems() {
-    umount "$rootdir/dev/pts"
-    umount "$rootdir/dev"
-    umount "$rootdir/proc"
-    umount "$rootdir/sys"
+    # XXX: Should be doing strict checks but /dev/pts seems to be
+    # prematurely unmounted for some reason perhaps due to issues in
+    # parallel builds.  Workaround that.
+    umount "$rootdir/dev/pts" || true
+    umount "$rootdir/dev" || true
+    umount "$rootdir/proc" || true
+    umount "$rootdir/sys" || true
 }
 
 # Set to true/false to control if eatmydata is used during build


### PR DESCRIPTION
Last night I had several build failures without this patch.  There is some weird issues with bind mounts when doing several builds at the same time on same machine.

Ideally, I would like avoid this patch.  However, it is not bad; if we fail to unmount any of the steps, it will lead to failure in final umount anyway.