### PR TITLE
Remove non-free Wi-Fi firmware from Dreamplug imgs

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -479,7 +479,6 @@ class DreamPlugImageBuilder(ARMImageBuilder):
     """Image builder for DreamPlug target."""
     architecture = 'armel'
     machine = 'dreamplug'
-    free = False
     kernel_flavor = 'kirkwood'
     boot_filesystem_type = 'vfat'
 

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -14,17 +14,6 @@ enable_serial_console() {
     echo "T0:12345:respawn:/sbin/getty -L $device 115200 vt100" >> /etc/inittab
 }
 
-dreamplug_install_extra_packages() {
-    # Install additional hardware related packages for Dreamplug
-    if [ -n "`grep non-free /etc/apt/sources.list`" ]
-    then
-        echo "Installing non-free WIFI package: firmware-libertas"
-        apt-get install -y firmware-libertas
-    else
-        echo "Non-free packages disabled.  Skipping DreamPlug non-free WIFI."
-    fi
-}
-
 dreamplug_flash() {
     # allow flash-kernel to work without valid /proc contents
     # ** this doesn't *really* work, since there are too many checks
@@ -128,7 +117,6 @@ setup_flash_kernel() {
 
 case "$MACHINE" in
     dreamplug|guruplug)
-	dreamplug_install_extra_packages
 	dreamplug_flash
 	dreamplug_repack_kernel
 	enable_serial_console ttyS0

--- a/freedommaker/tests/test_invocation.py
+++ b/freedommaker/tests/test_invocation.py
@@ -128,7 +128,7 @@ class TestInvocation(unittest.TestCase):
         distribution = distribution or 'unstable'
 
         free_tag = 'free'
-        if target in ('dreamplug', 'raspberry', 'raspberry2'):
+        if target in ('raspberry', 'raspberry2'):
             free_tag = 'nonfree'
 
         file_name = 'freedombox-{distribution}-{free_tag}_{build_stamp}_' \


### PR DESCRIPTION
Closes: #67.  Use of USB Wi-Fi dongles with free firmware are
recommended instead.

Freedom maker test cases are running fine.  Full image build is ongoing, will update when it is completed.