### PR TITLE
Add init to base packages

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -30,6 +30,7 @@ BASE_PACKAGES = [
     'base-files',
     'debian-archive-keyring',
     'ifupdown',
+    'init',
     'initramfs-tools',
     'kmod',
     'logrotate',


### PR DESCRIPTION
The init package is no longer marked as essential or required. Add it to our base packages list to ensure that it is installed in the image.

Fixes #74.