### PR TITLE
Remove debootstrap variants

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -26,16 +26,7 @@ import shutil
 import subprocess
 
 BASE_PACKAGES = [
-    'apt',
-    'base-files',
-    'debian-archive-keyring',
-    'ifupdown',
     'initramfs-tools',
-    'kmod',
-    'logrotate',
-    'netbase',
-    'rsyslog',
-    'udev',
 ]
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -52,6 +52,7 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
     boot_size = None
     boot_offset = None
     kernel_flavor = 'default'
+    debootstrap_variant = None
 
     @classmethod
     def get_target_name(cls):
@@ -306,7 +307,6 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
 class AMDIntelImageBuilder(ImageBuilder):
     """Base image build for all Intel/AMD targets."""
     boot_loader = 'grub'
-    debootstrap_variant = None
 
     @classmethod
     def get_target_name(cls):
@@ -425,7 +425,6 @@ class QemuI386ImageBuilder(QemuImageBuilder):
 class ARMImageBuilder(ImageBuilder):
     """Base image builder for all ARM targets."""
     boot_loader = 'u-boot'
-    debootstrap_variant = 'minbase'
     boot_filesystem_type = 'ext2'
     boot_size = '128M'
 

--- a/freedommaker/tests/test_invocation.py
+++ b/freedommaker/tests/test_invocation.py
@@ -346,9 +346,7 @@ class TestInvocation(unittest.TestCase):
     def test_base_packages(self):
         """Test that base packages are availble."""
         self.invoke()
-        for package in ['apt', 'base-files', 'debian-archive-keyring',
-                        'ifupdown', 'initramfs-tools', 'kmod', 'logrotate',
-                        'netbase', 'rsyslog', 'udev']:
+        for package in ['initramfs-tools']:
             self.assert_arguments_passed(['--package', package])
 
     def test_foreign_architecture(self):
@@ -456,8 +454,4 @@ class TestInvocation(unittest.TestCase):
         for target, architecture in ARCHITECTURES.items():
             self.build_stamp = self.random_string()
             self.invoke([target])
-            if architecture in ('i386', 'amd64'):
-                self.assert_arguments_not_passed(['--debootstrapopts'])
-            else:
-                self.assert_arguments_passed(
-                    ['--debootstrapopts', 'variant=minbase'])
+            self.assert_arguments_not_passed(['--debootstrapopts'])


### PR DESCRIPTION
Remove minbase as debootstrap variant:

For all images, uniformly use 'no variant'.  According to debootstrap
manual page, providing no variant will result in installing packages
with 'Priority: important' where as when using 'minbase' as variant only
'apt' is installed.  All packages marked as 'Priority: required' are
included in both cases.  See debootstrap:scripts/sid:work_out_debs().

This means:

- All images will have packages installed uniformly.  We can document
  the features reliably and depend on the packages reliably.

- There is no need to explictly list and manage important packages.
  Packages marked important by Debian developers will automatically be
  installed.

Remove explicit inclusion of important packages:

As we specify no variant to debootstrap, all important packages are
already installed.  There is no need to explicitly include important
packages.