### PR TITLE
Avoid error when signing, if signature file doesn't exist already

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -262,7 +262,10 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
             logger.info('Signature file up-to-date, skipping - %s', signature)
             return
 
-        os.remove(signature)
+        try:
+            os.remove(signature)
+        except FileNotFoundError:
+            pass
         self._run(['gpg', '--output', signature, '--detach-sig', archive])
 
     def should_skip_step(self, target, dependencies=None):


### PR DESCRIPTION
Currently an error will occur when using --sign with a fresh repository (or if build folder is removed).