### PR TITLE
Catch more errors

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 
 set -e
 set -x
+set -o pipefail
 
 enable_eatmydata_override() {
     chroot $rootdir apt-get install --no-install-recommends -y eatmydata

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+set -x
 
 # Raspberry Pi blob repo
 rpi_blob_repo='https://github.com/Hexxeh/rpi-update'

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 
 set -e
 set -x
+set -o pipefail
 
 # Raspberry Pi blob repo
 rpi_blob_repo='https://github.com/Hexxeh/rpi-update'


### PR DESCRIPTION
- Exit after error in hardware-setup.
- Use bash's pipefail option.

Note that Raspberry Pi builds are failing currently due to #86.
