### PR TITLE
Disable systemd-networkd

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -136,6 +136,7 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
             '--log-level', self.arguments.log_level,
             '--verbose',
             '--customize', self.customization_script,
+            '--no-systemd-networkd',
         ]
         self.environment = {
             'MIRROR': self.arguments.mirror,


### PR DESCRIPTION
Avoid issue with DNS during build. Network interfaces are handled by NetworkManager.

Fixes #86.
