### PR TITLE
WIP: Use Debian kernel and u-boot for Raspberry Pi 2

### DIFF
--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -488,7 +488,10 @@ class RaspberryPiImageBuilder(ARMImageBuilder):
     kernel_flavor = None
 
 
-class RaspberryPi2ImageBuilder(RaspberryPiImageBuilder):
+class RaspberryPi2ImageBuilder(ARMImageBuilder):
     """Image builder for Raspberry Pi 2 target."""
     architecture = 'armhf'
     machine = 'raspberry2'
+    free = False
+    boot_offset = '160mib'
+    kernel_flavor = 'armmp'

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -493,5 +493,5 @@ class RaspberryPi2ImageBuilder(ARMImageBuilder):
     architecture = 'armhf'
     machine = 'raspberry2'
     free = False
-    boot_offset = '160mib'
+    boot_offset = '64mib'
     kernel_flavor = 'armmp'

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -118,7 +118,7 @@ case "$MACHINE" in
 	umount "$rootdir"
 	kpartx -dvs "$image"
 
-	parted -s "$image" mkpart primary 0% 128MiB
+	parted -s "$image" mkpart primary 0% 60MiB
 
 	# Reorder partitions by start offset
 	sfdisk --reorder "$image"

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -126,6 +126,7 @@ case "$MACHINE" in
 	device=/dev/mapper/$(kpartx -avs "$image" \
 				    | awk '/^add map / {print $3; exit}')
 	mkfs -t vfat "$device"
+	parted -s "$image" set 1 lba on
 
 	mount -t btrfs "${device%?}3" "$rootdir"
 	mount -t ext2 "${device%?}2" "$rootdir"/boot

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -97,6 +97,12 @@ unmount_file_systems() {
     umount "$rootdir/dev" || true
     umount "$rootdir/proc" || true
     umount "$rootdir/sys" || true
+
+    case "$MACHINE" in
+	raspberry2)
+	    umount "$rootdir/boot/firmware" || true
+	    ;;
+    esac
 }
 
 # Set to true/false to control if eatmydata is used during build
@@ -104,6 +110,33 @@ use_eatmydata=true
 
 rootdir="$1"
 image="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
+
+# Create vfat /boot/firmware partition for devices that need it.
+case "$MACHINE" in
+    raspberry2)
+	umount "$rootdir/boot"
+	umount "$rootdir"
+	kpartx -dvs "$image"
+
+	parted -s "$image" mkpart primary 0% 128MiB
+
+	# Reorder partitions by start offset
+	sfdisk --reorder "$image"
+
+	device=/dev/mapper/$(kpartx -avs "$image" \
+				    | awk '/^add map / {print $3; exit}')
+	mkfs -t vfat "$device"
+
+	mount -t btrfs "${device%?}3" "$rootdir"
+	mount -t ext2 "${device%?}2" "$rootdir"/boot
+	mkdir "$rootdir/boot/firmware"
+	mount -t vfat "$device" "$rootdir/boot/firmware"
+
+	fs_uuid=$(blkid -c /dev/null -o value -s UUID "$device")
+	echo "UUID=$fs_uuid /boot/firmware vfat errors=remount-ro 0 3" \
+	     >>"$rootdir"/etc/fstab
+	;;
+esac
 
 mount_file_systems
 trap unmount_file_systems EXIT

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -91,33 +91,16 @@ raspberry_setup_boot() {
     SKIP_BACKUP=1 SKIP_WARNING=1 rpi-update | tee /root/rpi-update.log
 }
 
-# Install binary blob and kernel needed to boot on the Raspberry Pi 2.
+# Install binary blob and u-boot needed to boot on the Raspberry Pi 2.
 raspberry2_setup_boot() {
-    # Packages used by rpi-update to make Raspberry Pi bootable
-    apt-get install -y git-core binutils ca-certificates wget
+    # install boot firmware
+    apt-get install --no-install-recommends -y dpkg-dev
+    apt-get source raspi3-firmware
+    cp raspi3-firmware*/boot/* /boot/firmware
 
-    rpi_tempdir=/tmp/fbx-rpi-update
-    if [ -d $rpi_tempdir ]; then
-        rm -rf $rpi_tempdir
-    fi
-    git clone $rpi_blob_repo $rpi_tempdir
-    cd $rpi_tempdir
-    git checkout $rpi_blob_commit -b $rpi_blob_commit
-
-    downloaded_rpi_blob_hash=$(sha256sum $rpi_tempdir/rpi-update \
-				      | awk -F ' ' '{print $1}')
-    if [ "$downloaded_rpi_blob_hash" != "$rpi_blob_hash" ]; then
-        echo 'WARNING: Unable to verify Raspberry Pi boot blob'
-        return
-    fi
-
-    cp $rpi_tempdir/rpi-update /usr/bin/rpi-update
-
-    chmod a+x /usr/bin/rpi-update
-    touch /boot/firmware/start.elf
-    SKIP_BACKUP=1 SKIP_WARNING=1 SKIP_KERNEL=1 \
-	       ROOT_PATH=/ BOOT_PATH=/boot/firmware \
-	       rpi-update | tee /root/rpi-update.log
+    # remove unneeded firmware files
+    rm -f /boot/firmware/fixup_*
+    rm -f /boot/firmware/start_*
 
     # u-boot setup
     apt-get install -y u-boot-rpi

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -93,7 +93,35 @@ raspberry_setup_boot() {
 
 # Install binary blob and kernel needed to boot on the Raspberry Pi 2.
 raspberry2_setup_boot() {
-    raspberry_setup_boot
+    # Packages used by rpi-update to make Raspberry Pi bootable
+    apt-get install -y git-core binutils ca-certificates wget
+
+    rpi_tempdir=/tmp/fbx-rpi-update
+    if [ -d $rpi_tempdir ]; then
+        rm -rf $rpi_tempdir
+    fi
+    git clone $rpi_blob_repo $rpi_tempdir
+    cd $rpi_tempdir
+    git checkout $rpi_blob_commit -b $rpi_blob_commit
+
+    downloaded_rpi_blob_hash=$(sha256sum $rpi_tempdir/rpi-update \
+				      | awk -F ' ' '{print $1}')
+    if [ "$downloaded_rpi_blob_hash" != "$rpi_blob_hash" ]; then
+        echo 'WARNING: Unable to verify Raspberry Pi boot blob'
+        return
+    fi
+
+    cp $rpi_tempdir/rpi-update /usr/bin/rpi-update
+
+    chmod a+x /usr/bin/rpi-update
+    touch /boot/firmware/start.elf
+    SKIP_BACKUP=1 SKIP_WARNING=1 SKIP_KERNEL=1 \
+	       ROOT_PATH=/ BOOT_PATH=/boot/firmware \
+	       rpi-update | tee /root/rpi-update.log
+
+    # u-boot setup
+    apt-get install -y u-boot-rpi
+    cp /usr/lib/u-boot/rpi_2/u-boot.bin /boot/firmware/kernel.img
 }
 
 
@@ -126,6 +154,8 @@ case "$MACHINE" in
 	;;
     raspberry2)
 	raspberry2_setup_boot
+	setup_flash_kernel 'Raspberry Pi 2 Model B'
+	flash-kernel
 	;;
     beaglebone)
         setup_flash_kernel 'TI AM335x BeagleBone Black' 'ttyO0'


### PR DESCRIPTION
I haven't been able to get this to actually boot yet, so further changes may be required.

- Create /boot/firmware partition as vfat
- Use ext2 for /boot
- Use u-boot-rpi and armmp kernel
- Use flash-kernel to copy kernel to /boot

Notes:
- There is a different u-boot binary for Raspberry Pi 3, so we will likely need a separate image for it.
- I thought flash-kernel should be triggered automatically at install, but that wasn't happening. Will need to investigate further.

The partition table looks like this:
```
Number  Start   End     Size    Type     File system  Flags
 1      1049kB  134MB   133MB   primary  fat16
 2      160MB   282MB   122MB   primary  ext2         boot
 3      282MB   3799MB  3517MB  primary  btrfs
```
Here are the files under /boot:
/boot/lost+found
/boot/dtb-4.9.0-2-armmp
/boot/System.map-4.9.0-2-armmp
/boot/vmlinuz-4.9.0-2-armmp
/boot/dtbs
/boot/dtbs/4.9.0-2-armmp
/boot/dtbs/4.9.0-2-armmp/bcm2836-rpi-2-b.dtb
/boot/dtb
/boot/boot.scr
/boot/initrd.img-4.9.0-2-armmp
/boot/config-4.9.0-2-armmp
/boot/firmware
/boot/firmware/start.elf
/boot/firmware/start_cd.elf
/boot/firmware/start_db.elf
/boot/firmware/start_x.elf
/boot/firmware/bootcode.bin
/boot/firmware/fixup.dat
/boot/firmware/fixup_cd.dat
/boot/firmware/fixup_db.dat
/boot/firmware/fixup_x.dat
/boot/firmware/.firmware_revision
/boot/firmware/kernel.img
