### PR TITLE
Provide source packages outside of image

### DIFF
--- a/freedommaker/application.py
+++ b/freedommaker/application.py
@@ -33,6 +33,7 @@ IMAGE_SIZE = '3800M'
 BUILD_MIRROR = 'http://deb.debian.org/debian'
 MIRROR = 'http://deb.debian.org/debian'
 DISTRIBUTION = 'unstable'
+DOWNLOAD_SOURCE = False
 INCLUDE_SOURCE = False
 BUILD_DIR = 'build'
 LOG_LEVEL = 'debug'
@@ -101,6 +102,9 @@ class Application(object):
         parser.add_argument(
             '--distribution', default=DISTRIBUTION,
             help='Debian release to use in built image')
+        parser.add_argument(
+            '--download-source', action='store_true', default=DOWNLOAD_SOURCE,
+            help='Whether to download source packages')
         parser.add_argument(
             '--include-source', action='store_true', default=INCLUDE_SOURCE,
             help='Whether to include source in build image')

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -141,7 +141,8 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
             'MIRROR': self.arguments.mirror,
             'BUILD_MIRROR': self.arguments.build_mirror,
             'MACHINE': self.machine,
-            'SOURCE': 'true' if self.arguments.include_source else 'false',
+            'SOURCE': 'true' if self.arguments.download_source else 'false',
+            'SOURCE_IN_IMAGE': 'true' if self.arguments.include_source else 'false',
             'SUITE': self.arguments.distribution,
             'ENABLE_NONFREE': 'no' if self.free else 'yes',
         }

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -113,6 +113,14 @@ unmount_file_systems() {
     esac
 }
 
+make_source_tarball() {
+    # Make source packages available outside of image.
+    (
+    cd "$rootdir/usr/src/packages"
+    tar -czvf "$1" ./*
+    )
+}
+
 # Set to true/false to control if eatmydata is used during build
 use_eatmydata=true
 
@@ -212,6 +220,15 @@ rm $rootdir/usr/sbin/policy-rc.d
 
 chroot $rootdir /usr/lib/freedombox/setup 2>&1 | \
     tee $rootdir/var/log/freedombox-setup.log
+
+if [ 'true' = "$SOURCE" ] ; then
+    make_source_tarball "${image%.img.temp}"-source.tar.gz
+
+    if [ 'false' = "$SOURCE_IN_IMAGE" ] ; then
+	# Remove source packages from image.
+	rm -rf "$rootdir/usr/src/packages"
+    fi
+fi
 
 # Remove SSH keys from the image, freedomxbox-setup does not do that
 # anymore.

--- a/freedommaker/tests/test_invocation.py
+++ b/freedommaker/tests/test_invocation.py
@@ -237,13 +237,21 @@ class TestInvocation(unittest.TestCase):
         self.assert_environment_passed({'SUITE': distribution},
                                        distribution=distribution)
 
-    def test_include_source(self):
-        """Test that include-source parameter works."""
+    def test_download_source(self):
+        """Test that download-source parameter works."""
         self.invoke()
         self.assert_environment_passed({'SOURCE': 'false'})
 
-        self.invoke(include_source=True, force=True)
+        self.invoke(download_source=True, force=True)
         self.assert_environment_passed({'SOURCE': 'true'})
+
+    def test_include_source(self):
+        """Test that include-source parameter works."""
+        self.invoke()
+        self.assert_environment_passed({'SOURCE_IN_IMAGE': 'false'})
+
+        self.invoke(include_source=True, force=True)
+        self.assert_environment_passed({'SOURCE_IN_IMAGE': 'true'})
 
     def test_package(self):
         """Test that package parameter works."""


### PR DESCRIPTION
This adds a 'download-source' option, which controls whether source
packages will be downloaded. The source packages are placed in a
tarball, outside of the image.

The original option, 'include-source', is now used to specify whether
to keep the source packages in the image as well.

Closes #34.