### PR TITLE
[WIP] Add raspberry3 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Freedom-maker supports building for the following targets:
 - *dreamplug*: DreamPlug's internal SD card
 - *raspberry*: RasbperryPi's SD card.
 - *raspberry2*: RasbperryPi 2's SD card.
+- *raspberry3*: RasbperryPi 3's SD card.
 - *i386*: Disk image for any machine with i386 architecture
 - *amd64*: Disk image for any machine with amd64 architecture.
 - *virtualbox-i386*: 32-bit image for the VirtualBox virtualization tool
@@ -96,8 +97,8 @@ $ sudo apt-get install extlinux virtualbox sshpass
 
 2. Build all images:
     ```
-    $ python3 -m freedommaker dreamplug raspberry raspberry2 beaglebone \
-      cubieboard2 cubietruck a20-olinuxino-lime a20-olinuxino-lime2 \
+    $ python3 -m freedommaker dreamplug raspberry raspberry2 raspberry3 \
+      beaglebone cubieboard2 cubietruck a20-olinuxino-lime a20-olinuxino-lime2 \
       a20-olinuxino-micro i386 amd64 virtualbox-i386 virtualbox-amd64 \
       qemu-i386 qemu-amd64
     ```

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -170,7 +170,10 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
     def process_architecture(self):
         """Add parameters specific to the architecture."""
         if self.architecture not in ('i386', 'amd64'):
-            self.parameters += ['--foreign', '/usr/bin/qemu-arm-static']
+            if self.architecture == 'arm64':
+                self.parameters += ['--foreign', '/usr/bin/qemu-aarch64-static']
+            else:
+                self.parameters += ['--foreign', '/usr/bin/qemu-arm-static']
 
             # Using taskset to pin build process to single core. This
             # is a workaround for a qemu-user-static issue that causes
@@ -566,3 +569,13 @@ class RaspberryPi2ImageBuilder(ARMImageBuilder):
     free = False
     boot_offset = '64mib'
     kernel_flavor = 'armmp'
+
+
+class RaspberryPi3ImageBuilder(ARMImageBuilder):
+    """Image builder for Raspberry Pi 3 target."""
+    architecture = 'arm64'
+    machine = 'raspberry3'
+    free = False
+    boot_loader = None
+    boot_offset = '64mib'
+    kernel_flavor = 'arm64'

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -108,7 +108,7 @@ unmount_file_systems() {
     umount "$rootdir/sys" || true
 
     case "$MACHINE" in
-	raspberry2)
+	raspberry2 | raspberry3)
 	    umount "$rootdir/boot/firmware" || true
 	    ;;
     esac
@@ -130,7 +130,7 @@ image="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
 
 # Create vfat /boot/firmware partition for devices that need it.
 case "$MACHINE" in
-    raspberry2)
+    raspberry2 | raspberry3)
 	umount "$rootdir/boot"
 	umount "$rootdir"
 	kpartx -dvs "$image"

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -127,6 +127,25 @@ raspberry2_setup_boot() {
     cp /usr/lib/u-boot/rpi_2/u-boot.bin /boot/firmware/kernel.img
 }
 
+# Install binary blob and u-boot needed to boot on the Raspberry Pi 3.
+raspberry3_setup_boot() {
+    # install boot firmware
+    apt-get install --no-install-recommends -y dpkg-dev
+    cd /tmp
+    apt-get source raspi3-firmware
+    cp raspi3-firmware*/boot/* /boot/firmware
+    rm -rf raspi3-firmware*
+    cd /
+
+    # remove unneeded firmware files
+    rm -f /boot/firmware/fixup_*
+    rm -f /boot/firmware/start_*
+
+    # u-boot setup
+    apt-get install -y u-boot-rpi u-boot-tools
+    cp /usr/lib/u-boot/rpi_3/u-boot.bin /boot/firmware/kernel.img
+}
+
 
 setup_flash_kernel() {
     if [ ! -d /etc/flash-kernel ] ; then
@@ -144,6 +163,16 @@ setup_flash_kernel() {
     fi
 
     apt-get install -y flash-kernel
+
+    # add machine db entry for Raspberry Pi 3
+    cat >>/etc/flash-kernel/db <<EOF
+Machine: Raspberry Pi 3 Model B
+Kernel-Flavors: arm64
+DTB-Id: bcm2837-rpi-3-b.dtb
+U-Boot-Script-Name: bootscr.uboot-generic
+Required-Packages: u-boot-tools
+Boot-Script-Path: /boot/boot.scr
+EOF
 }
 
 stable_mac_address_workaround() {
@@ -174,6 +203,11 @@ case "$MACHINE" in
         setup_flash_kernel 'Raspberry Pi 2 Model B'
         flash-kernel
         stable_mac_address_workaround
+        ;;
+    raspberry3)
+        raspberry3_setup_boot
+        setup_flash_kernel 'Raspberry Pi 3 Model B'
+        flash-kernel
         ;;
     beaglebone)
         setup_flash_kernel 'TI AM335x BeagleBone Black' 'ttyO0'

--- a/freedommaker/tests/test_invocation.py
+++ b/freedommaker/tests/test_invocation.py
@@ -52,6 +52,7 @@ ARCHITECTURES = {
     'dreamplug': 'armel',
     'raspberry': 'armel',
     'raspberry2': 'armhf',
+    'raspberry3': 'arm64',
 }
 
 
@@ -123,12 +124,13 @@ class TestInvocation(unittest.TestCase):
             'dreamplug': 'dreamplug-armel.img',
             'raspberry': 'raspberry-armel.img',
             'raspberry2': 'raspberry2-armhf.img',
+            'raspberry3': 'raspberry3-arm64.img',
         }
 
         distribution = distribution or 'unstable'
 
         free_tag = 'free'
-        if target in ('raspberry', 'raspberry2'):
+        if target in ('raspberry', 'raspberry2', 'raspberry3'):
             free_tag = 'nonfree'
 
         file_name = 'freedombox-{distribution}-{free_tag}_{build_stamp}_' \
@@ -379,7 +381,7 @@ class TestInvocation(unittest.TestCase):
                 self.assert_arguments_not_passed(['--package', 'u-boot'])
                 self.assert_arguments_not_passed(['--package', 'u-boot-tools'])
                 self.assert_arguments_not_passed(['--no-extlinux'])
-            elif target in ('raspberry', 'raspberry2'):
+            elif target in ('raspberry'):
                 self.assert_arguments_not_passed(['--grub'])
                 self.assert_arguments_not_passed(['--package', 'u-boot'])
                 self.assert_arguments_not_passed(['--package', 'u-boot-tools'])
@@ -404,7 +406,7 @@ class TestInvocation(unittest.TestCase):
                 self.assert_arguments_not_passed(['--boottype'])
                 self.assert_arguments_passed(['--package', 'btrfs-tools'])
                 self.assert_arguments_not_passed(['--bootsize', '128M'])
-            elif target in ('raspberry', 'raspberry2'):
+            elif target in ('raspberry'):
                 self.assert_arguments_passed(['--roottype', 'ext4'])
                 self.assert_arguments_passed(['--boottype', 'vfat'])
                 self.assert_arguments_not_passed(['--package', 'btrfs-tools'])
@@ -425,7 +427,7 @@ class TestInvocation(unittest.TestCase):
         for target, architecture in ARCHITECTURES.items():
             self.build_stamp = self.random_string()
             self.invoke([target])
-            if target in ('raspberry', 'raspberry2', 'dreamplug') or \
+            if target in ('raspberry', 'dreamplug') or \
                architecture in ('i386', 'amd64'):
                 self.assert_arguments_not_passed(['--bootoffset'])
             elif target in ('beaglebone'):
@@ -445,9 +447,17 @@ class TestInvocation(unittest.TestCase):
                 self.assert_arguments_not_passed(['--no-kernel'])
                 self.assert_arguments_passed(
                     ['--kernel-package', 'linux-image-armmp'])
-            elif target in ('raspberry', 'raspberry2'):
+            elif target in ('raspberry'):
                 self.assert_arguments_passed(['--no-kernel'])
                 self.assert_arguments_not_passed(['--kernel-package'])
+            elif target in ('raspberry2'):
+                self.assert_arguments_not_passed(['--no-kernel'])
+                self.assert_arguments_passed(
+                    ['--kernel-package', 'linux-image-armmp-lpae'])
+            elif target in ('raspberry3'):
+                self.assert_arguments_notpassed(['--no-kernel'])
+                self.assert_arguments_passed(
+                    ['--kernel-package', 'linux-image-arm64'])
             elif target in ('dreamplug'):
                 self.assert_arguments_not_passed(['--no-kernel'])
                 self.assert_arguments_passed(


### PR DESCRIPTION
I was able to build an image, but I haven't gotten it to boot yet.
- Requires vmdebootstrap to have this patch applied: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845439
- Patch for flash-kernel submitted here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=869488
- It's possible to just install raspi3-firmware on arm64, in which case it would it runs a kernel postinst hook (https://anonscm.debian.org/cgit/pkg-raspi/raspi3-firmware.git/tree/debian/kernel/postinst.d/raspi3-firmware). I think this is not used with u-boot or flash-kernel though.
- There's also a Debian live image built with these scripts: https://people.debian.org/~stapelberg/raspberrypi3/2017-03-22/