### PR TITLE
WIP: File-based flag to indicate FreedomBox images

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -186,6 +186,11 @@ esac
 set_apt_sources $BUILD_MIRROR
 chroot $rootdir apt-get update
 
+# Set a flag to indicate that this is a FreedomBox image
+# and FreedomBox is not installed using a Debian package
+mkdir -p $rootdir/var/lib/freedombox
+touch $rootdir/var/lib/freedombox/is-freedombox-disk-image
+
 cat > $rootdir/usr/sbin/policy-rc.d <<EOF
 #!/bin/sh
 exit 101


### PR DESCRIPTION
Create a file called /var/lib/freedombox/is-freedombox-disk-image to
indicate that this image was created by freedom-maker.