### PR TITLE
WIP: Add support for building images for Pine A64+

### DIFF
--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -286,6 +286,12 @@ case "$MACHINE" in
         dd if=$rootdir/usr/lib/u-boot/Linksprite_pcDuino3/u-boot-sunxi-with-spl.bin of="$image" \
            seek=8 conv=notrunc bs=1k
         ;;
+    pine64-plus)
+        dd if=$rootdir/usr/lib/u-boot/pine64_plus/sunxi-spl.bin of="$image" \
+           seek=8 conv=notrunc bs=1k
+        dd if=$rootdir/usr/lib/u-boot/pine64_plus/u-boot.bin of="$image" \
+           seek=40 conv=notrunc bs=1k
+        ;;
 esac
 
 if $use_eatmydata ; then

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -196,4 +196,7 @@ case "$MACHINE" in
     pcduino3)
         setup_flash_kernel 'LinkSprite pcDuino3'
         ;;
+    pine64-plus)
+        setup_flash_kernel 'Pine64+'
+        ;;
 esac


### PR DESCRIPTION
Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

The current state is that images are built successfully. Boot happens for SPL, ATF and u-boot.  u-boot is able load the boot script, then kernel, dtb and initrd. However:
- Kernel does not show any messages or show any further progress (such as running systemd or initrd). I assumed that the upstream/Debian kernel does not have enough board support bits to actually boot the board. More work is scheduled to be mered into next kernel releases. See https://linux-sunxi.org/Linux_mainlining_effort .
- The dtb path in /boot is placed by flash-kernel in the wrong path due to a bug in flash-kernel: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=860304.  This affects many arm64 boards and can be easily worked around.