### PR TITLE
raspberry3: New image and target for Raspberry Pi 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Freedom-maker supports building for the following targets:
 - *dreamplug*: DreamPlug's internal SD card
 - *raspberry*: RasbperryPi's SD card.
 - *raspberry2*: RasbperryPi 2's SD card.
+- *raspberry3*: RasbperryPi 3's SD card.
 - *i386*: Disk image for any machine with i386 architecture
 - *amd64*: Disk image for any machine with amd64 architecture.
 - *virtualbox-i386*: 32-bit image for the VirtualBox virtualization tool
@@ -96,8 +97,8 @@ $ sudo apt-get install virtualbox sshpass
 
 2. Build all images:
     ```
-    $ python3 -m freedommaker dreamplug raspberry raspberry2 beaglebone \
-      cubieboard2 cubietruck a20-olinuxino-lime a20-olinuxino-lime2 \
+    $ python3 -m freedommaker dreamplug raspberry raspberry2 raspberry3 \
+      beaglebone cubieboard2 cubietruck a20-olinuxino-lime a20-olinuxino-lime2 \
       a20-olinuxino-micro i386 amd64 virtualbox-i386 virtualbox-amd64 \
       qemu-i386 qemu-amd64 banana-pro
     ```

--- a/doc/freedom-maker.xml
+++ b/doc/freedom-maker.xml
@@ -196,8 +196,8 @@
         <listitem>
           <para>
             Image targets to build. Choose one or more of freedommaker,
-            dreamplug, raspberry, raspberry2, beaglebone, cubieboard2,
-            cubietruck, a20-olinuxino-lime, a20-olinuxino-lime2,
+            dreamplug, raspberry, raspberry2, raspberry3, beaglebone,
+            cubieboard2, cubietruck, a20-olinuxino-lime, a20-olinuxino-lime2,
             a20-olinuxino-micro, i386, amd64, virtualbox-i386, virtualbox-amd64,
             qemu-i386, qemu-amd64, pcduino3, banana-pro
           </para>
@@ -220,9 +220,9 @@
     <example>
       <title>Build all images</title>
       <synopsis>$ python3 -m freedommaker dreamplug raspberry raspberry2
-      beaglebone cubieboard2 cubietruck a20-olinuxino-lime a20-olinuxino-lime2 
-      a20-olinuxino-micro i386 amd64 virtualbox-i386 virtualbox-amd64 
-      qemu-i386 qemu-amd64 pcDuino3</synopsis>
+      raspberry3 beaglebone cubieboard2 cubietruck a20-olinuxino-lime
+      a20-olinuxino-lime2 a20-olinuxino-micro i386 amd64 virtualbox-i386
+      virtualbox-amd64 qemu-i386 qemu-amd64 pcduino3 banana-pro</synopsis>
       <para>
         Build all the available FreedomBox images using freedom-maker.
       </para>

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -573,3 +573,12 @@ class RaspberryPi2ImageBuilder(ARMImageBuilder):
     free = False
     boot_offset = '64mib'
     kernel_flavor = 'armmp'
+
+
+class RaspberryPi3ImageBuilder(ARMImageBuilder):
+    """Image builder for Raspberry Pi 3 target."""
+    architecture = 'armhf'
+    machine = 'raspberry3'
+    free = False
+    boot_offset = '64mib'
+    kernel_flavor = 'armmp'

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -110,9 +110,9 @@ unmount_file_systems() {
     umount "$rootdir/sys" || true
 
     case "$MACHINE" in
-	raspberry2)
-	    umount "$rootdir/boot/firmware" || true
-	    ;;
+        raspberry2 | raspberry3)
+            umount "$rootdir/boot/firmware" || true
+        ;;
     esac
 }
 
@@ -132,30 +132,30 @@ image="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
 
 # Create vfat /boot/firmware partition for devices that need it.
 case "$MACHINE" in
-    raspberry2)
-	umount "$rootdir/boot"
-	umount "$rootdir"
-	kpartx -dvs "$image"
+    raspberry2 | raspberry3)
+        umount "$rootdir/boot"
+        umount "$rootdir"
+        kpartx -dvs "$image"
 
-	parted -s "$image" mkpart primary 0% 60MiB
+        parted -s "$image" mkpart primary 0% 60MiB
 
-	# Reorder partitions by start offset
-	sfdisk --reorder "$image"
+        # Reorder partitions by start offset
+        sfdisk --reorder "$image"
 
-	device=/dev/mapper/$(kpartx -avs "$image" \
-				    | awk '/^add map / {print $3; exit}')
-	mkfs -t vfat "$device"
-	parted -s "$image" set 1 lba on
+        device=/dev/mapper/$(kpartx -avs "$image" \
+            | awk '/^add map / {print $3; exit}')
+        mkfs -t vfat "$device"
+        parted -s "$image" set 1 lba on
 
-	mount -t btrfs "${device%?}3" "$rootdir"
-	mount -t ext2 "${device%?}2" "$rootdir"/boot
-	mkdir "$rootdir/boot/firmware"
-	mount -t vfat "$device" "$rootdir/boot/firmware"
+        mount -t btrfs "${device%?}3" "$rootdir"
+        mount -t ext2 "${device%?}2" "$rootdir"/boot
+        mkdir "$rootdir/boot/firmware"
+        mount -t vfat "$device" "$rootdir/boot/firmware"
 
-	fs_uuid=$(blkid -c /dev/null -o value -s UUID "$device")
-	echo "UUID=$fs_uuid /boot/firmware vfat errors=remount-ro 0 3" \
-	     >>"$rootdir"/etc/fstab
-	;;
+        fs_uuid=$(blkid -c /dev/null -o value -s UUID "$device")
+        echo "UUID=$fs_uuid /boot/firmware vfat errors=remount-ro 0 3" \
+             >>"$rootdir"/etc/fstab
+        ;;
 esac
 
 mount_file_systems

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -141,7 +141,21 @@ setup_flash_kernel() {
     if [ ! -d /etc/flash-kernel ] ; then
        mkdir /etc/flash-kernel
     fi
-    echo -n "$1" > /etc/flash-kernel/machine
+    full_machine_name="$1"
+    echo -n "$full_machine_name" > /etc/flash-kernel/machine
+
+    # Raspberry Pi 3 Model B can also work with armmp kernel, so add it to the
+    # flash-kernel database in addition to the existing arm64. XXX: Remove this
+    # override when flash-kernel is updated.
+    case "$full_machine_name" in
+        "Raspberry Pi 3 Model B")
+            mkdir -p /usr/share/flash-kernel/db/
+            cat >/usr/share/flash-kernel/db/01-raspberrypi3-freedombox.db <<EOF
+Machine: Raspberry Pi 3 Model B
+Kernel-Flavors: arm64 armmp armmp-lpae
+EOF
+            ;;
+    esac
 
     command_line=""
     if [ -n "$2" ] ; then

--- a/freedommaker/hardware-setup
+++ b/freedommaker/hardware-setup
@@ -109,7 +109,9 @@ raspberry_setup_boot() {
 }
 
 # Install binary blob and u-boot needed to boot on the Raspberry Pi 2.
-raspberry2_setup_boot() {
+raspberry2or3_setup_boot() {
+    pi_version="$1"
+
     # install boot firmware
     apt-get install --no-install-recommends -y dpkg-dev
     cd /tmp
@@ -124,7 +126,14 @@ raspberry2_setup_boot() {
 
     # u-boot setup
     apt-get install -y u-boot-rpi
-    cp /usr/lib/u-boot/rpi_2/u-boot.bin /boot/firmware/kernel.img
+    case "$pi_version" in
+        raspberry2)
+            cp /usr/lib/u-boot/rpi_2/u-boot.bin /boot/firmware/kernel.img
+            ;;
+        raspberry3)
+            cp /usr/lib/u-boot/rpi_3_32b/u-boot.bin /boot/firmware/kernel.img
+            ;;
+    esac
 }
 
 
@@ -170,8 +179,14 @@ case "$MACHINE" in
         raspberry_setup_boot
         ;;
     raspberry2)
-        raspberry2_setup_boot
+        raspberry2or3_setup_boot 'raspberry2'
         setup_flash_kernel 'Raspberry Pi 2 Model B'
+        flash-kernel
+        stable_mac_address_workaround
+        ;;
+    raspberry3)
+        raspberry2or3_setup_boot 'raspberry3'
+        setup_flash_kernel 'Raspberry Pi 3 Model B'
         flash-kernel
         stable_mac_address_workaround
         ;;

--- a/freedommaker/tests/test_invocation.py
+++ b/freedommaker/tests/test_invocation.py
@@ -53,6 +53,7 @@ ARCHITECTURES = {
     'dreamplug': 'armel',
     'raspberry': 'armel',
     'raspberry2': 'armhf',
+    'raspberry3': 'armhf',
 }
 
 
@@ -125,12 +126,13 @@ class TestInvocation(unittest.TestCase):
             'dreamplug': 'dreamplug-armel.img',
             'raspberry': 'raspberry-armel.img',
             'raspberry2': 'raspberry2-armhf.img',
+            'raspberry3': 'raspberry3-armhf.img',
         }
 
         distribution = distribution or 'unstable'
 
         free_tag = 'free'
-        if target in ('raspberry', 'raspberry2'):
+        if target in ('raspberry', 'raspberry2', 'raspberry3'):
             free_tag = 'nonfree'
 
         file_name = 'freedombox-{distribution}-{free_tag}_{build_stamp}_' \
@@ -386,7 +388,7 @@ class TestInvocation(unittest.TestCase):
                 self.assert_arguments_not_passed(['--package', 'u-boot'])
                 self.assert_arguments_not_passed(['--package', 'u-boot-tools'])
                 self.assert_arguments_passed(['--no-extlinux'])
-            elif target in ('raspberry2'):
+            elif target in ('raspberry2', 'raspberry3'):
                 self.assert_arguments_not_passed(['--grub'])
                 self.assert_arguments_passed(['--package', 'u-boot'])
                 self.assert_arguments_passed(['--package', 'u-boot-tools'])
@@ -416,7 +418,7 @@ class TestInvocation(unittest.TestCase):
                 self.assert_arguments_passed(['--boottype', 'vfat'])
                 self.assert_arguments_not_passed(['--package', 'btrfs-progs'])
                 self.assert_arguments_passed(['--bootsize', '128M'])
-            elif target in ('raspberry2'):
+            elif target in ('raspberry2', 'raspberry3'):
                 self.assert_arguments_passed(['--roottype', 'btrfs'])
                 self.assert_arguments_passed(['--boottype', 'ext2'])
                 self.assert_arguments_passed(['--package', 'btrfs-progs'])
@@ -440,7 +442,7 @@ class TestInvocation(unittest.TestCase):
             if target in ('raspberry', 'dreamplug') or \
                architecture in ('i386', 'amd64'):
                 self.assert_arguments_not_passed(['--bootoffset'])
-            elif target in ('raspberry2'):
+            elif target in ('raspberry2', 'raspberry3'):
                 self.assert_arguments_passed(['--bootoffset', '64mib'])
             elif target in ('beaglebone'):
                 self.assert_arguments_passed(['--bootoffset', '2mib'])
@@ -466,7 +468,7 @@ class TestInvocation(unittest.TestCase):
             elif target in ('raspberry'):
                 self.assert_arguments_passed(['--no-kernel'])
                 self.assert_arguments_not_passed(['--kernel-package'])
-            elif target in ('raspberry2'):
+            elif target in ('raspberry2', 'raspberry3'):
                 self.assert_arguments_passed(
                     ['--kernel-package', 'linux-image-armmp'])
             elif target in ('dreamplug'):


### PR DESCRIPTION
This is still a 32bit binary image. This is a stop gap measure until the real
64bit version is available. The 64bit version is not ready yet and images meant
for Raspberry Pi 2 are not working for Raspberry Pi 3 due to different in u-boot
binary required. The image also uses a DTB that is specifically meant for
Raspberry Pi 3.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

I haven't built and tested this image yet.  I have tested that Raspberry Pi 2 image with a changed u-boot and DTB works works well with Raspberry Pi 3.