### PR TITLE
Cleanup loop devices properly after build

### DIFF
--- a/freedommaker/application.py
+++ b/freedommaker/application.py
@@ -71,10 +71,14 @@ class Application(object):
 
             builder = cls(self.arguments)
             self.setup_logging(builder.log_file)
-            builder.build()
-            builder.cleanup()
-
-            logger.info('Target complete - %s', target)
+            try:
+                builder.build()
+                logger.info('Target complete - %s', target)
+            except:
+                logger.error('Target failed - %s', target)
+                raise
+            finally:
+                builder.cleanup()
 
     def parse_arguments(self):
         """Parse command line arguments."""

--- a/freedommaker/application.py
+++ b/freedommaker/application.py
@@ -130,6 +130,10 @@ class Application(object):
             '--force', action='store_true',
             help='Force rebuild of images even when required image exists')
         parser.add_argument(
+            '--build-in-ram', action='store_true',
+            help='Build the image in RAM so that it is faster, requires '
+            'free RAM about the size of disk image')
+        parser.add_argument(
             'targets', nargs='+', help='Image targets to build')
 
         self.arguments = parser.parse_args()

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -24,6 +24,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 
 from . import vmdb2
 from . import vmdebootstrap
@@ -73,6 +74,8 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
         self.arguments = arguments
         self.packages = BASE_PACKAGES
 
+        self.ram_directory = None
+
         self.builder_backends = {}
         self.builder_backends['vmdebootstrap'] = \
             vmdebootstrap.VmdebootstrapBuilderBackend(self)
@@ -96,6 +99,10 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
     def cleanup(self):
         """Finalize tasks."""
         logger.removeHandler(self.log_handler)
+        if self.ram_directory:
+            self._run(['umount', self.ram_directory.name])
+            self.ram_directory.cleanup()
+            self.ram_directory = None
 
     def build(self):
         """Run the image building process."""
@@ -124,6 +131,25 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
                 distribution=self.arguments.distribution, free_tag=free_tag,
                 build_stamp=self.arguments.build_stamp, machine=self.machine,
                 architecture=self.architecture)
+
+    def get_temp_image_file(self):
+        """Get the temporary path to where the image should be built.
+
+        If building to RAM is enabled, create a temporary directory, mount
+        tmpfs in it and return a path in that directory. This is so that builds
+        that happen in RAM will be faster.
+
+        If building to RAM is disabled, append .temp to the final file name and
+        return it.
+
+        """
+        if not self.arguments.build_in_ram:
+            return self.image_file + '.temp'
+
+        self.ram_directory = tempfile.TemporaryDirectory()
+        self._run(['mount', '-t', 'tmpfs', 'tmpfs', self.ram_directory.name])
+        return os.path.join(self.ram_directory.name,
+                            os.path.basename(self.image_file))
 
     def compress(self, archive_file, image_file):
         """Compress the generate image."""

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -98,11 +98,13 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
 
     def cleanup(self):
         """Finalize tasks."""
-        logger.removeHandler(self.log_handler)
+        logger.info('Cleaning up')
         if self.ram_directory:
             self._run(['sudo', 'umount', self.ram_directory.name])
             self.ram_directory.cleanup()
             self.ram_directory = None
+
+        logger.removeHandler(self.log_handler)
 
     def build(self):
         """Run the image building process."""

--- a/freedommaker/builder.py
+++ b/freedommaker/builder.py
@@ -100,7 +100,7 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
         """Finalize tasks."""
         logger.removeHandler(self.log_handler)
         if self.ram_directory:
-            self._run(['umount', self.ram_directory.name])
+            self._run(['sudo', 'umount', self.ram_directory.name])
             self.ram_directory.cleanup()
             self.ram_directory = None
 
@@ -147,7 +147,8 @@ class ImageBuilder(object):  # pylint: disable=too-many-instance-attributes
             return self.image_file + '.temp'
 
         self.ram_directory = tempfile.TemporaryDirectory()
-        self._run(['mount', '-t', 'tmpfs', 'tmpfs', self.ram_directory.name])
+        self._run(
+            ['sudo', 'mount', '-t', 'tmpfs', 'tmpfs', self.ram_directory.name])
         return os.path.join(self.ram_directory.name,
                             os.path.basename(self.image_file))
 

--- a/freedommaker/freedombox-customize
+++ b/freedommaker/freedombox-customize
@@ -17,36 +17,6 @@ set -e
 set -x
 set -o pipefail
 
-enable_eatmydata_override() {
-    chroot $rootdir apt-get install --no-install-recommends -y eatmydata
-    if [ -x $rootdir/usr/bin/eatmydata ] && \
-        [ ! -f $rootdir/etc/apt/apt.conf.d/95debian-edu-install-dpkg-eatmydata ]; then
-        echo "info: Adding apt config to call dpkg via eatmydata"
-        printf "#!/bin/sh\nexec eatmydata dpkg \"\$@\"\n" \
-            > $rootdir/var/tmp/dpkg-eatmydata
-        chmod 755 $rootdir/var/tmp/dpkg-eatmydata
-        cat > $rootdir/etc/apt/apt.conf.d/95debian-edu-install-dpkg-eatmydata <<EOF
-Dir::Bin::dpkg "/var/tmp/dpkg-eatmydata";
-EOF
-    else
-        echo "error: unable to find /usr/bin/eatmydata after installing the eatmydata package"
-    fi
-}
-
-disable_eatmydata_override() {
-    for override in \
-        /etc/apt/apt.conf.d/95debian-edu-install-dpkg-eatmydata \
-        /var/tmp/dpkg-eatmydata ; do
-        echo "info: Removing apt config to call dpkg via eatmydata"
-        if [ -f $rootdir$override ] ; then
-            rm -f $rootdir$override
-        else
-            echo "warning: missing $rootdir$override"
-        fi
-    done
-    sync # Flush file buffers before continuing
-}
-
 set_apt_sources() {
     NEW_MIRROR="$1"
     COMPONENTS="main"
@@ -124,9 +94,6 @@ make_source_tarball() {
     )
 }
 
-# Set to true/false to control if eatmydata is used during build
-use_eatmydata=true
-
 rootdir="$1"
 image="$(cd "$(dirname "$2")"; pwd)/$(basename "$2")"
 
@@ -198,10 +165,6 @@ cat > $rootdir/usr/sbin/policy-rc.d <<EOF
 exit 101
 EOF
 chmod a+rx $rootdir/usr/sbin/policy-rc.d
-
-if $use_eatmydata ; then
-    enable_eatmydata_override
-fi
 
 if [ -n "$CUSTOM_PLINTH" ]; then
     cp "$CUSTOM_PLINTH" "$rootdir"/tmp
@@ -291,10 +254,6 @@ case "$MACHINE" in
            seek=8 conv=notrunc bs=1k
         ;;
 esac
-
-if $use_eatmydata ; then
-    disable_eatmydata_override
-fi
 
 set_apt_sources $MIRROR
 chroot $rootdir apt-get update

--- a/freedommaker/vmdebootstrap.py
+++ b/freedommaker/vmdebootstrap.py
@@ -19,7 +19,7 @@ Basic image builder using vmdebootstrap.
 """
 
 import logging
-import os
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,8 @@ class VmdebootstrapBuilderBackend():
                         self.builder.image_file)
             return
 
-        temp_image_file = self.builder.image_file + '.temp'
+        temp_image_file = self.builder.get_temp_image_file()
+        logger.info('Building image in temporary file - %s', temp_image_file)
         self.execution_wrapper = ['sudo', '-H']
         self.parameters = [
             '--hostname',
@@ -90,14 +91,16 @@ class VmdebootstrapBuilderBackend():
         ] + self.parameters
         self.builder._run(command)
 
-        os.rename(temp_image_file, self.builder.image_file)
+        logger.info('Moving file: %s -> %s', temp_image_file,
+                    self.builder.image_file)
+        shutil.move(temp_image_file, self.builder.image_file)
 
     def process_variant(self):
         """Add paramaters for deboostrap variant."""
         if self.builder.debootstrap_variant:
             self.parameters += [
-                '--debootstrapopts', 'variant=' +
-                self.builder.debootstrap_variant
+                '--debootstrapopts',
+                'variant=' + self.builder.debootstrap_variant
             ]
 
     def process_architecture(self):


### PR DESCRIPTION
When building for platforms that are not i386/amd64, vmdebootstrap ends up not
cleaning up loop back devices properly. For each successful build disk space
ends up not getting freed due to open file handles. In case of building in RAM,
the temporary directory can't be removed and RAM is not freed up.

Work around the problem by force cleaning loop devices after vmdebootstrap is
finished.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

This patch is on top of the build-in-ram #136 branch as I could more easily work with this branch and test. The actual changes are only the last commit.